### PR TITLE
Limitation on pressing conflicting signals

### DIFF
--- a/src/styles/components/_alert.scss
+++ b/src/styles/components/_alert.scss
@@ -1,0 +1,12 @@
+.error-alert {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    background-color: #f44336; /* czerwone tło */
+    color: white;
+    padding: 10px 20px;
+    font-weight: bold;
+    z-index: 1000; /* nad innymi elementami */
+    text-align: center;
+  }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -12,6 +12,7 @@
 @use "layout/toggle";
 
 @use "components/aiChat";
+@use "components/alert";
 @use "components/bus";
 @use "components/buttons";
 @use "components/calc";


### PR DESCRIPTION
* Added mutual-exclusion checks for signal buttons (e.g. wyad vs. wyl, wys vs. wyak, il vs. wel, czyt vs. pisz, and “one JAML operation at a time”).
* When the user tries to enable a conflicting signal, a red alert appears at the top of the screen.
* The alert’s timeout is reset on each new conflict attempt so it remains visible for the full duration, even under rapid clicks.
* Introduced a flag to block further signal toggles while the alert is shown.