### PR TITLE
Highlighting incorrect signals fix

### DIFF
--- a/src/components/ProgramEditor.vue
+++ b/src/components/ProgramEditor.vue
@@ -22,7 +22,12 @@
       :value="code"
       placeholder="rozkaz"
       @input="$emit('update:code', $event.target.value)"
+      spellcheck="false"
+      autocorrect="off"
+      autocomplete="off"
+      autocapitalize="off"
     />
+
 
     <div v-else class="compiledCode">
       <span


### PR DESCRIPTION
Disabled browser text suggestions on the ProgramEditor textarea by adding spellcheck="false", autocorrect="off", autocomplete="off", and autocapitalize="off". This ensures that entered commands aren’t underlined or auto-corrected.